### PR TITLE
fix: correção nos comandos CREATE para definir corretamente CreatedAt…

### DIFF
--- a/src/Ambev.DeveloperEvaluation.Application/Ambev.DeveloperEvaluation.Application.csproj
+++ b/src/Ambev.DeveloperEvaluation.Application/Ambev.DeveloperEvaluation.Application.csproj
@@ -16,7 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="SaleItem\DeleteSaleItem\" />
     <Folder Include="SaleItem\GetSaleItem\" />
   </ItemGroup>
 

--- a/src/Ambev.DeveloperEvaluation.Application/Branch/CreateBranch/CreateBranchCommand.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Branch/CreateBranch/CreateBranchCommand.cs
@@ -32,6 +32,16 @@ namespace Ambev.DeveloperEvaluation.Application.Branch.CreateBranch
         public bool IsActive { get; set; } = true;
         
         /// <summary>
+        /// Gets or sets the creation date of the branch.
+        /// </summary>
+        public DateTime CreatedAt { get; set; } = DateTime.Now;
+
+        /// <summary>
+        /// Gets or sets the last update date of the branch.
+        /// </summary>
+        public DateTime UpdatedAt { get; set; } = DateTime.Now;
+        
+        /// <summary>
         /// Validates the current branch creation command using the defined validator.
         /// </summary>
         /// <returns>

--- a/src/Ambev.DeveloperEvaluation.Application/Customer/CreateCustomer/CreateCustomerCommand.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Customer/CreateCustomer/CreateCustomerCommand.cs
@@ -37,6 +37,16 @@ namespace Ambev.DeveloperEvaluation.Application.Customer.CreateCustomer
         public bool IsActive { get; set; } = true;
         
         /// <summary>
+        /// Gets or sets the creation date of the customer.
+        /// </summary>
+        public DateTime CreatedAt { get; set; } = DateTime.Now;
+
+        /// <summary>
+        /// Gets or sets the last update date of the customer.
+        /// </summary>
+        public DateTime UpdatedAt { get; set; } = DateTime.Now;
+        
+        /// <summary>
         /// Validates the current customer creation command using the defined validator.
         /// </summary>
         /// <returns>

--- a/src/Ambev.DeveloperEvaluation.Application/Product/CreateProduct/CreateProductCommand.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Product/CreateProduct/CreateProductCommand.cs
@@ -34,6 +34,16 @@ namespace Ambev.DeveloperEvaluation.Application.Product.CreateProduct
         public bool IsActive { get; set; } = true;
         
         /// <summary>
+        /// Gets or sets the creation date of the product.
+        /// </summary>
+        public DateTime CreatedAt { get; set; } = DateTime.Now;
+
+        /// <summary>
+        /// Gets or sets the last update date of the product.
+        /// </summary>
+        public DateTime UpdatedAt { get; set; } = DateTime.Now;
+        
+        /// <summary>
         /// Validates the current product creation command using the defined validator.
         /// </summary>
         /// <returns>

--- a/src/Ambev.DeveloperEvaluation.Application/Sale/CreateSale/CreateSaleCommand.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sale/CreateSale/CreateSaleCommand.cs
@@ -49,6 +49,16 @@ public class CreateSaleCommand : IRequest<CreateSaleResult>
     public bool IsCancelled { get; set; } = false;
     
     /// <summary>
+    /// Gets or sets the creation date of the sale.
+    /// </summary>
+    public DateTime CreatedAt { get; set; } = DateTime.Now;
+
+    /// <summary>
+    /// Gets or sets the last update date of the sale.
+    /// </summary>
+    public DateTime UpdatedAt { get; set; } = DateTime.Now;
+    
+    /// <summary>
     /// List of sale items associated with this sale.
     /// </summary>
     public ICollection<CreateSaleItemCommand> SaleItems { get; set; } = new List<CreateSaleItemCommand>();


### PR DESCRIPTION
… e UpdatedAt

- Ajustado o preenchimento dos campos CreatedAt e UpdatedAt na criação de Sale, Customer, Product e Branch
- Garantido que a data de criação e atualização seja definida no momento da persistência